### PR TITLE
feat: reviews overview

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,12 @@ enum InviteStatus {
   EXPIRED
 }
 
+enum ReviewType {
+  USER
+  CLUB
+  EVENT
+}
+
 model User {
   id            String  @id @default(cuid())
   email         String  @unique
@@ -54,6 +60,9 @@ model User {
   banned                    Boolean?
   banReason                 String?
   banExpires                DateTime?
+
+  reviewsReceived Review[] @relation("UserReviews")
+  reviewsWritten  Review[] @relation("ReviewAuthor")
 }
 
 model Club {
@@ -85,6 +94,8 @@ model Club {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  reviews Review[]
 }
 
 model ClubRule {
@@ -177,6 +188,8 @@ model Event {
   updatedAt         DateTime            @updatedAt
   eventRegistration EventRegistration[]
   eventInvite       EventInvite[]
+
+  reviews Review[]
 }
 
 model EventRegistration {
@@ -271,4 +284,29 @@ model Passkey {
   backedUp       Boolean
   transports     String?
   createdAt      DateTime?
+}
+
+model Review {
+  id        String     @id @default(cuid())
+  type      ReviewType
+  rating    Int        @db.SmallInt // 1-5 stars
+  content   String
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  // Who wrote the review
+  authorId String
+  author   User   @relation("ReviewAuthor", fields: [authorId], references: [id], onDelete: Cascade)
+
+  // What was reviewed (only one of these will be set)
+  userId    String?
+  user      User?   @relation("UserReviews", fields: [userId], references: [id], onDelete: Cascade)
+  clubId    String?
+  club      Club?   @relation(fields: [clubId], references: [id], onDelete: Cascade)
+  eventId   String?
+  event     Event?  @relation(fields: [eventId], references: [id], onDelete: Cascade)
+
+  @@unique([authorId, userId])
+  @@unique([authorId, clubId])
+  @@unique([authorId, eventId])
 }

--- a/src/app/(public)/clubs/[id]/page.tsx
+++ b/src/app/(public)/clubs/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { ClubOverview } from "@/components/club-overview";
+import { ClubOverview } from "@/components/overviews/club-overview";
 
 interface PageProps {
 	params: Promise<{

--- a/src/app/(public)/events/[id]/page.tsx
+++ b/src/app/(public)/events/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { EventOverview } from "@/components/event-overview";
+import { EventOverview } from "@/components/overviews/event-overview";
 import { isAuthenticated } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";

--- a/src/app/(public)/users/[id]/page.tsx
+++ b/src/app/(public)/users/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { UserOverview } from "@/components/user-overview";
+import { UserOverview } from "@/components/overviews/user-overview";
 
 interface PageProps {
 	params: Promise<{

--- a/src/app/dashboard/(club)/[clubId]/club/page.tsx
+++ b/src/app/dashboard/(club)/[clubId]/club/page.tsx
@@ -1,7 +1,7 @@
 import { isAuthenticated } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { ClubOverview } from "@/components/club-overview";
+import { ClubOverview } from "@/components/overviews/club-overview";
 
 interface PageProps {
 	params: Promise<{

--- a/src/app/dashboard/(club)/[clubId]/club/stats/_components/stats-charts.tsx
+++ b/src/app/dashboard/(club)/[clubId]/club/stats/_components/stats-charts.tsx
@@ -68,7 +68,7 @@ export function StatsCharts({
 			},
 		},
 		events: {
-			label: "Eventi po mjesecu",
+			label: "Susreti po mjesecu",
 			theme: {
 				light: "hsl(346.8 77.2% 49.8%)",
 				dark: "hsl(346.8 77.2% 49.8%)",

--- a/src/app/dashboard/(club)/[clubId]/events/[id]/attendance/_components/attendance-tracker.tsx
+++ b/src/app/dashboard/(club)/[clubId]/events/[id]/attendance/_components/attendance-tracker.tsx
@@ -153,6 +153,7 @@ export function AttendanceTracker({ event }: AttendanceTrackerProps) {
 					<Button
 						variant={registration.attended ? "destructive" : "default"}
 						size="sm"
+						className="ml-4"
 						onClick={() => handleToggleAttendance(registration)}
 						disabled={isLoading === registration.id}
 					>

--- a/src/app/dashboard/(club)/[clubId]/events/[id]/page.tsx
+++ b/src/app/dashboard/(club)/[clubId]/events/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { EventOverview } from "@/components/event-overview";
+import { EventOverview } from "@/components/overviews/event-overview";
 import { isAuthenticated } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";

--- a/src/app/dashboard/(user)/user/page.tsx
+++ b/src/app/dashboard/(user)/user/page.tsx
@@ -1,7 +1,7 @@
 import { isAuthenticated } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { notFound } from "next/navigation";
-import { UserOverview } from "@/components/user-overview";
+import { UserOverview } from "@/components/overviews/user-overview";
 import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
 import { Eye, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/overviews/club-overview.tsx
+++ b/src/components/overviews/club-overview.tsx
@@ -1,9 +1,15 @@
-"use client";
-
 import { Badge } from "@/components/ui/badge";
-import type { Club } from "@prisma/client";
-import { AtSign, Eye, EyeOff, MapPin, Phone, User } from "lucide-react";
+import type { Club, Review, User } from "@prisma/client";
+import {
+	AtSign,
+	Eye,
+	EyeOff,
+	MapPin,
+	Phone,
+	User as UserIcon,
+} from "lucide-react";
 import Image from "next/image";
+import { ReviewsOverview } from "@/components/overviews/reviews/reviews-overview";
 
 interface ClubOverviewProps {
 	club: Club & {
@@ -15,7 +21,7 @@ interface ClubOverviewProps {
 
 export function ClubOverview({ club }: ClubOverviewProps) {
 	return (
-		<>
+		<div className="space-y-6">
 			<div className="flex gap-4">
 				{/* TODO: Handle if unset */}
 				{club.logo && (
@@ -36,7 +42,7 @@ export function ClubOverview({ club }: ClubOverviewProps) {
 			</div>
 			<div className="flex flex-wrap gap-1">
 				<Badge variant="outline" className="flex items-center gap-1">
-					<User className="w-4 h-4" />
+					<UserIcon className="w-4 h-4" />
 					{club._count?.members}
 				</Badge>
 				<Badge variant="outline" className="flex items-center gap-1">
@@ -71,6 +77,7 @@ export function ClubOverview({ club }: ClubOverviewProps) {
 					</Badge>
 				)}
 			</div>
-		</>
+			<ReviewsOverview type="club" typeId={club.id} />
+		</div>
 	);
 }

--- a/src/components/overviews/event-overview.tsx
+++ b/src/components/overviews/event-overview.tsx
@@ -5,10 +5,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { isAuthenticated } from "@/lib/auth";
 import { cn } from "@/lib/utils";
-import type { ClubRule, Event } from "@prisma/client";
-import { Eye, EyeOff, MapPin, Pencil, User } from "lucide-react";
+import type { ClubRule, Event, Review, User } from "@prisma/client";
+import { Eye, EyeOff, MapPin, Pencil, UserIcon } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { ReviewsOverview } from "@/components/overviews/reviews/reviews-overview";
 
 interface EventOverviewProps {
 	event: Event & {
@@ -25,7 +26,7 @@ export async function EventOverview({ event, clubId }: EventOverviewProps) {
 	const canEdit = user?.managedClubs.some((club) => club === clubId);
 
 	return (
-		<div className="relative flex flex-col items-center justify-center gap-4 ">
+		<div className="relative flex flex-col items-center justify-center gap-4">
 			{event.coverImage && (
 				<>
 					<Eye className="size-8 z-20 text-black bg-white border p-0.5 absolute top-4 right-4 peer" />
@@ -87,7 +88,7 @@ export async function EventOverview({ event, clubId }: EventOverviewProps) {
 
 					<div className="flex flex-wrap gap-1 -mt-2">
 						<Badge variant="outline" className="flex h-fit items-center gap-1">
-							<User className="size-4" />
+							<UserIcon className="size-4" />
 							{event._count?.eventRegistration} prijavljenih
 						</Badge>
 						<Badge variant="outline" className="flex h-fit items-center gap-1">
@@ -141,6 +142,7 @@ export async function EventOverview({ event, clubId }: EventOverviewProps) {
 								</LoadChildOnClick>
 							</div>
 						)}
+					<ReviewsOverview type="event" typeId={event.id} />
 				</div>
 			</div>
 		</div>

--- a/src/components/overviews/reviews/reviews-overview-sheet.tsx
+++ b/src/components/overviews/reviews/reviews-overview-sheet.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Star } from "lucide-react";
+import { format } from "date-fns";
+import { useState } from "react";
+import type { User } from "@prisma/client";
+
+interface Review {
+	id: string;
+	rating: number;
+	content: string;
+	createdAt: Date;
+	author: Pick<User, "name" | "image">;
+}
+
+interface ReviewsOverviewSheetProps {
+	reviews: Review[];
+	title: string;
+}
+
+export function ReviewsOverviewSheet({
+	reviews,
+	title,
+}: ReviewsOverviewSheetProps) {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<Sheet open={isOpen} onOpenChange={setIsOpen}>
+			<SheetTrigger asChild>
+				<Button variant="outline" className="w-fit">
+					Prikaži sve ocjene
+				</Button>
+			</SheetTrigger>
+
+			<SheetContent side="right" className="w-full sm:w-[540px]">
+				<div className="h-full flex flex-col gap-4">
+					<SheetHeader>
+						<SheetTitle>Ocjene</SheetTitle>
+						<SheetDescription>Sve ocjene za {title}</SheetDescription>
+					</SheetHeader>
+					<div className="flex-1 overflow-y-auto">
+						<div className="space-y-4">
+							{reviews.map((review) => (
+								<div key={review.id} className="space-y-1">
+									<div className="flex items-center gap-1">
+										{[1, 2, 3, 4, 5].map((star) => (
+											<Star
+												key={star}
+												className={`h-4 w-4 ${
+													star <= review.rating
+														? "fill-yellow-400 text-yellow-400"
+														: "fill-muted text-muted"
+												}`}
+											/>
+										))}
+									</div>
+									<p className="text-sm">{review.content}</p>
+									<p className="text-xs text-muted-foreground">
+										{review.author.name} •{" "}
+										{format(review.createdAt, "dd.MM.yyyy")}
+									</p>
+								</div>
+							))}
+						</div>
+					</div>
+				</div>
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/src/components/overviews/reviews/reviews-overview.tsx
+++ b/src/components/overviews/reviews/reviews-overview.tsx
@@ -1,0 +1,139 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Star } from "lucide-react";
+import { prisma } from "@/lib/prisma";
+import { notFound } from "next/navigation";
+import { ReviewsOverviewSheet } from "@/components/overviews/reviews/reviews-overview-sheet";
+import { format } from "date-fns";
+
+interface ReviewsOverviewProps {
+	type: "club" | "event" | "user";
+	typeId: string;
+}
+
+export async function ReviewsOverview({ type, typeId }: ReviewsOverviewProps) {
+	// Fetch reviews based on type
+	let reviews;
+	switch (type) {
+		case "club": {
+			const club = await prisma.review.findMany({
+				where: { clubId: typeId },
+				include: {
+					author: {
+						select: {
+							name: true,
+							image: true,
+						},
+					},
+				},
+				orderBy: { createdAt: "desc" },
+			});
+			reviews = club;
+			break;
+		}
+		case "event": {
+			const event = await prisma.review.findMany({
+				where: { eventId: typeId },
+				include: {
+					author: {
+						select: {
+							name: true,
+							image: true,
+						},
+					},
+				},
+				orderBy: { createdAt: "desc" },
+			});
+			reviews = event;
+			break;
+		}
+		case "user": {
+			const user = await prisma.review.findMany({
+				where: { userId: typeId },
+				include: {
+					author: {
+						select: {
+							name: true,
+							image: true,
+						},
+					},
+				},
+				orderBy: { createdAt: "desc" },
+			});
+			reviews = user;
+			break;
+		}
+		default:
+			return notFound();
+	}
+
+	const title =
+		type === "club" ? "klub" : type === "event" ? "susret" : "korisnik";
+
+	const averageRating =
+		reviews.length > 0
+			? reviews.reduce((acc, review) => acc + review.rating, 0) / reviews.length
+			: 0;
+
+	return (
+		<Card>
+			<CardHeader className="pb-2">
+				<CardTitle>Ocjene</CardTitle>
+			</CardHeader>
+			<CardContent>
+				<div className="flex flex-col gap-4">
+					<div className="flex items-center gap-1">
+						{[1, 2, 3, 4, 5].map((star) => (
+							<Star
+								key={star}
+								className={`h-6 w-6 ${
+									star <= averageRating
+										? "fill-yellow-400 text-yellow-400"
+										: "fill-muted text-muted"
+								}`}
+							/>
+						))}
+						<span className="ml-2 text-sm text-muted-foreground">
+							({reviews.length})
+						</span>
+					</div>
+
+					{reviews.length > 0 ? (
+						<>
+							<h2 className="text-lg font-semibold">Najnovije ocjene</h2>
+							<div className="flex flex-col md:flex-row gap-4 items-start justify-between">
+								{reviews?.slice(0, 3).map((review) => (
+									<div key={review.id} className="space-y-1">
+										<div className="flex items-center gap-1">
+											{[1, 2, 3, 4, 5].map((star) => (
+												<Star
+													key={star}
+													className={`h-4 w-4 ${
+														star <= review.rating
+															? "fill-yellow-400 text-yellow-400"
+															: "fill-muted text-muted"
+													}`}
+												/>
+											))}
+										</div>
+										<p className="text-sm">
+											{review.content?.slice(0, 50)}
+											{review.content.length > 50 ? "(...)" : ""}
+										</p>
+										<p className="text-xs text-muted-foreground">
+											{review.author.name} •{" "}
+											{format(review.createdAt, "dd.MM.yyyy")}
+										</p>
+									</div>
+								))}
+							</div>
+
+							<ReviewsOverviewSheet reviews={reviews} title={title} />
+						</>
+					) : (
+						<p className="text-sm text-muted-foreground">Nema ocjena</p>
+					)}
+				</div>
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/components/overviews/user-overview.tsx
+++ b/src/components/overviews/user-overview.tsx
@@ -1,5 +1,6 @@
+import { ReviewsOverview } from "@/components/overviews/reviews/reviews-overview";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import type { Club, User, Event } from "@prisma/client";
+import type { Club, User, Event, Review } from "@prisma/client";
 import { format } from "date-fns";
 import Image from "next/image";
 import Link from "next/link";
@@ -92,7 +93,7 @@ export function UserOverview({ user }: UserOverviewProps) {
 
 				<Card>
 					<CardHeader>
-						<CardTitle>Predstojeći eventi</CardTitle>
+						<CardTitle>Predstojeći susreti</CardTitle>
 					</CardHeader>
 					<CardContent>
 						{futureEvents.length === 0 ? (
@@ -119,7 +120,7 @@ export function UserOverview({ user }: UserOverviewProps) {
 
 				<Card>
 					<CardHeader>
-						<CardTitle>Prethodni eventi</CardTitle>
+						<CardTitle>Prethodni susreti</CardTitle>
 					</CardHeader>
 					<CardContent>
 						{pastEvents.length === 0 ? (
@@ -144,6 +145,7 @@ export function UserOverview({ user }: UserOverviewProps) {
 					</CardContent>
 				</Card>
 			</div>
+			<ReviewsOverview type="user" typeId={user.id} />
 		</div>
 	);
 }


### PR DESCRIPTION
- added review overviews to clubs, events, and users, both on dashboard and public side.
- disabled deleting/updating events after they've finished. 
	- this will help bypass hiding bad reviews. 
	- should we keep the reviews if the club is deleted? 


We should add a way to add/edit/delete/report reviews as well.