### PR TITLE
fix: deletion tracking

### DIFF
--- a/messages/bs.json
+++ b/messages/bs.json
@@ -130,6 +130,15 @@
 				"description": "Stranica nije pronađena"
 			}
 		},
+		"deleted": {
+			"title": "Ova stranica je obrisana",
+			"message": "Sadržaj koji tražite je obrisan i više nije dostupan.",
+			"backHome": "Vrati se na početnu stranicu",
+			"metadata": {
+				"title": "Obrisano - RECONNED",
+				"description": "Ovaj sadržaj je obrisan i više nije dostupan."
+			}
+		},
 		"home": {
 			"hero": {
 				"button": "Pogledajte listu izmjena",
@@ -689,7 +698,15 @@
 				"save": "Spasi promjene",
 				"bioPlaceholder": "Nešto o meni je to da...",
 				"phoneDescription": "Ovako vas ljudi mogu kontaktirati",
-				"linkTaken": "Link je zauzet"
+				"linkTaken": "Link je zauzet",
+				"deleteAccount": {
+					"title": "Obriši račun",
+					"description": "Jednom kada obrišete račun, nema povratka. Molimo budite sigurni.",
+					"button": "Obriši račun",
+					"confirmTitle": "Jeste li potpuno sigurni?",
+					"confirmDescription": "Ova radnja se ne može poništiti. Ovo će trajno obrisati vaš račun i ukloniti vaše podatke sa naših servera. Ako ste posljednji član bilo kojeg kluba, oni će postati nepreuzeti.",
+					"confirmButton": "Da, obriši moj račun"
+				}
 			},
 			"security": {}
 		},

--- a/messages/en.json
+++ b/messages/en.json
@@ -130,6 +130,15 @@
 				"description": "The page you are looking for does not exist."
 			}
 		},
+		"deleted": {
+			"title": "This page has been deleted",
+			"message": "The content you are looking for has been deleted and is no longer available.",
+			"backHome": "Return to homepage",
+			"metadata": {
+				"title": "Deleted - RECONNED",
+				"description": "This content has been deleted and is no longer available."
+			}
+		},
 		"home": {
 			"hero": {
 				"button": "View the changelog",
@@ -689,7 +698,15 @@
 				"save": "Save changes",
 				"bioPlaceholder": "Something about me is that...",
 				"phoneDescription": "This is how people can reach you",
-				"linkTaken": "Link taken"
+				"linkTaken": "Link taken",
+				"deleteAccount": {
+					"title": "Delete account",
+					"description": "Once you delete your account, there is no going back. Please be certain.",
+					"button": "Delete account",
+					"confirmTitle": "Are you absolutely sure?",
+					"confirmDescription": "This action cannot be undone. This will permanently delete your account and remove your data from our servers. If you are the last member of any clubs, they will become unclaimed.",
+					"confirmButton": "Yes, delete my account"
+				}
 			},
 			"security": {}
 		},

--- a/prisma/audit.prisma
+++ b/prisma/audit.prisma
@@ -24,3 +24,15 @@ model ClubAuditLog {
   @@index([actionType])
   @@index([createdAt])
 }
+
+// Track deleted entities to show "deleted" pages instead of 404
+model DeletedEntity {
+  id        String     @id @default(ulid())
+  entityId  String
+  entityType EntityType
+  deletedAt DateTime   @default(now())
+
+  @@unique([entityId, entityType])
+  @@index([entityId])
+  @@index([entityType])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,3 +28,10 @@ enum ReviewType {
   CLUB
   EVENT
 }
+
+enum EntityType {
+  USER
+  CLUB
+  EVENT
+  MEMBER
+}

--- a/src/app/[locale]/(public)/clubs/[id]/page.tsx
+++ b/src/app/[locale]/(public)/clubs/[id]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import type { SportsOrganization, WithContext } from "schema-dts";
-import NotFoundTemporary from "@/app/[locale]/not-found";
 import JsonLdScript from "@/components/json-ld-script";
 import { ClubOverview } from "@/components/overviews/club-overview";
 import { isAuthenticated } from "@/lib/auth";
@@ -70,9 +69,31 @@ export default async function Page(props: PageProps<"/[locale]/clubs/[id]">) {
 		: null;
 
 	if (!club) {
-		// TODO https://github.com/vercel/next.js/issues/63388
-		// notFound();
-		return <NotFoundTemporary />;
+		const deletedEntity = await prisma.deletedEntity.findFirst({
+			where: {
+				entityType: "CLUB",
+				entityId: params.id,
+			},
+		});
+
+		if (deletedEntity) {
+			const DeletedPage = (await import("@/components/deleted-page")).default;
+			return <DeletedPage />;
+		}
+
+		notFound();
+	}
+
+	const deletedEntity = await prisma.deletedEntity.findFirst({
+		where: {
+			entityType: "CLUB",
+			entityId: club.id,
+		},
+	});
+
+	if (deletedEntity) {
+		const DeletedPage = (await import("@/components/deleted-page")).default;
+		return <DeletedPage />;
 	}
 
 	const sportsOrganizationSchema: WithContext<SportsOrganization> = {

--- a/src/app/[locale]/(public)/events/[id]/page.tsx
+++ b/src/app/[locale]/(public)/events/[id]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import type { SportsEvent, WithContext } from "schema-dts";
-import NotFoundTemporary from "@/app/[locale]/not-found";
 import JsonLdScript from "@/components/json-ld-script";
 import { EventOverview } from "@/components/overviews/event-overview";
 import { isAuthenticated } from "@/lib/auth";
@@ -62,9 +61,31 @@ export default async function Page(props: PageProps<"/[locale]/events/[id]">) {
 	});
 
 	if (!event) {
-		// TODO https://github.com/vercel/next.js/issues/63388
-		// notFound();
-		return <NotFoundTemporary />;
+		const deletedEntity = await prisma.deletedEntity.findFirst({
+			where: {
+				entityType: "EVENT",
+				entityId: params.id,
+			},
+		});
+
+		if (deletedEntity) {
+			const DeletedPage = (await import("@/components/deleted-page")).default;
+			return <DeletedPage />;
+		}
+
+		notFound();
+	}
+
+	const deletedEntity = await prisma.deletedEntity.findFirst({
+		where: {
+			entityType: "EVENT",
+			entityId: event.id,
+		},
+	});
+
+	if (deletedEntity) {
+		const DeletedPage = (await import("@/components/deleted-page")).default;
+		return <DeletedPage />;
 	}
 
 	const locale = await getLocale();

--- a/src/app/[locale]/(public)/users/[id]/page.tsx
+++ b/src/app/[locale]/(public)/users/[id]/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
 import type { Person, ProfilePage, WithContext } from "schema-dts";
-import NotFoundTemporary from "@/app/[locale]/not-found";
 import JsonLdScript from "@/components/json-ld-script";
 import { UserOverview } from "@/components/overviews/user-overview";
 import { env } from "@/lib/env";
@@ -41,9 +40,31 @@ export default async function Page(props: PageProps<"/[locale]/users/[id]">) {
 	});
 
 	if (!user) {
-		// TODO https://github.com/vercel/next.js/issues/63388
-		// notFound();
-		return <NotFoundTemporary />;
+		const deletedEntity = await prisma.deletedEntity.findFirst({
+			where: {
+				entityType: "USER",
+				entityId: params.id,
+			},
+		});
+
+		if (deletedEntity) {
+			const DeletedPage = (await import("@/components/deleted-page")).default;
+			return <DeletedPage />;
+		}
+
+		notFound();
+	}
+
+	const deletedEntity = await prisma.deletedEntity.findFirst({
+		where: {
+			entityType: "USER",
+			entityId: user.id,
+		},
+	});
+
+	if (deletedEntity) {
+		const DeletedPage = (await import("@/components/deleted-page")).default;
+		return <DeletedPage />;
 	}
 
 	// Filter out private events and private clubs

--- a/src/app/[locale]/dashboard/(club)/[clubId]/club/information/_components/club-info.action.ts
+++ b/src/app/[locale]/dashboard/(club)/[clubId]/club/information/_components/club-info.action.ts
@@ -264,14 +264,23 @@ export const disconnectInstagramAccount = safeActionClient
 	});
 
 export const deleteClub = safeActionClient.inputSchema(deleteClubSchema).action(async ({ ctx }) => {
+	const clubId = ctx.club.id;
 	const [, , locale] = await Promise.all([
-		prisma.club.delete({
-			where: {
-				id: ctx.club.id,
-			},
+		prisma.$transaction(async (tx) => {
+			await tx.deletedEntity.create({
+				data: {
+					entityId: clubId,
+					entityType: "CLUB",
+				},
+			});
+			await tx.club.delete({
+				where: {
+					id: clubId,
+				},
+			});
 		}),
 		deleteClubImage({
-			clubId: ctx.club.id,
+			clubId,
 		}),
 		getLocale(),
 	]);
@@ -287,9 +296,9 @@ export const deleteClub = safeActionClient.inputSchema(deleteClubSchema).action(
 	});
 
 	revalidateTag("managed-clubs", "max");
-	revalidateLocalizedPaths(`/dashboard/${ctx.club.id}`, "layout");
+	revalidateLocalizedPaths(`/dashboard/${clubId}`, "layout");
 	if (!ctx.club.isPrivate) {
-		revalidateLocalizedPaths(`/clubs/${ctx.club.slug ?? ctx.club.id}`);
+		revalidateLocalizedPaths(`/clubs/${ctx.club.slug ?? clubId}`);
 		revalidateLocalizedPaths("/clubs");
 		revalidateLocalizedPaths("/search");
 	}

--- a/src/app/[locale]/dashboard/(club)/[clubId]/events/create/_components/events.action.ts
+++ b/src/app/[locale]/dashboard/(club)/[clubId]/events/create/_components/events.action.ts
@@ -192,11 +192,19 @@ export const deleteEvent = safeActionClient.inputSchema(deleteEventSchema).actio
 	}
 
 	const [event, _] = await Promise.all([
-		prisma.event.delete({
-			where: {
-				id: parsedInput.eventId,
-				clubId: ctx.club.id,
-			},
+		prisma.$transaction(async (tx) => {
+			await tx.deletedEntity.create({
+				data: {
+					entityId: parsedInput.eventId,
+					entityType: "EVENT",
+				},
+			});
+			return await tx.event.delete({
+				where: {
+					id: parsedInput.eventId,
+					clubId: ctx.club.id,
+				},
+			});
 		}),
 		await deleteEventImage({
 			eventId: parsedInput.eventId,

--- a/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/members.action.ts
+++ b/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/members.action.ts
@@ -33,10 +33,18 @@ export const removeMember = safeActionClient.inputSchema(removeMemberSchema).act
 			throw new Error("Član nije pronađen ili je vlasnik kluba.");
 		}
 
-		await prisma.clubMembership.delete({
-			where: {
-				id: parsedInput.memberId,
-			},
+		await prisma.$transaction(async (tx) => {
+			await tx.deletedEntity.create({
+				data: {
+					entityId: parsedInput.memberId,
+					entityType: "MEMBER",
+				},
+			});
+			await tx.clubMembership.delete({
+				where: {
+					id: parsedInput.memberId,
+				},
+			});
 		});
 
 		await logClubAudit({

--- a/src/app/[locale]/dashboard/(platform)/admin/clubs/_components/club.actions.ts
+++ b/src/app/[locale]/dashboard/(platform)/admin/clubs/_components/club.actions.ts
@@ -24,8 +24,16 @@ export const clubAdminAction = safeActionClient.inputSchema(clubAdminActionSchem
 			data: { banned: false, banReason: null, banExpires: null },
 		});
 	} else if (action === "remove") {
-		await prisma.club.delete({
-			where: { id: clubId },
+		await prisma.$transaction(async (tx) => {
+			await tx.deletedEntity.create({
+				data: {
+					entityId: clubId,
+					entityType: "CLUB",
+				},
+			});
+			await tx.club.delete({
+				where: { id: clubId },
+			});
 		});
 	}
 

--- a/src/app/[locale]/dashboard/(user)/user/settings/_components/user-info.action.ts
+++ b/src/app/[locale]/dashboard/(user)/user/settings/_components/user-info.action.ts
@@ -137,3 +137,76 @@ export const deleteUserHeaderImage = safeActionClient.action(async ({ ctx }) => 
 		revalidateLocalizedPaths("/search");
 	}
 });
+
+export const deleteAccount = safeActionClient.action(async ({ ctx }) => {
+	const userId = ctx.user.id;
+
+	const clubsWhereUserIsOwner = await prisma.club.findMany({
+		where: {
+			members: {
+				some: {
+					userId,
+					role: "CLUB_OWNER",
+				},
+			},
+		},
+		include: {
+			members: {
+				where: {
+					role: "CLUB_OWNER",
+				},
+			},
+		},
+	});
+
+	const orphanedClubs = clubsWhereUserIsOwner.filter((club) => club.members.length === 1);
+
+	await prisma.$transaction(async (tx) => {
+		for (const club of orphanedClubs) {
+			await tx.clubMembership.deleteMany({
+				where: {
+					clubId: club.id,
+					userId,
+				},
+			});
+		}
+
+		await tx.deletedEntity.create({
+			data: {
+				entityId: userId,
+				entityType: "USER",
+			},
+		});
+
+		const user = await tx.user.findUnique({
+			where: { id: userId },
+			select: { image: true, headerImage: true },
+		});
+
+		if (user?.image) {
+			try {
+				await deleteS3File(`user/${userId}/image`);
+			} catch (error) {
+				logger.warn("Failed to delete user image from S3:", { error });
+			}
+		}
+
+		if (user?.headerImage) {
+			try {
+				await deleteS3File(`user/${userId}/header`);
+			} catch (error) {
+				logger.warn("Failed to delete user header image from S3:", { error });
+			}
+		}
+
+		await tx.user.delete({
+			where: { id: userId },
+		});
+	});
+
+	const locale = await getLocale();
+	return redirect({
+		href: "/",
+		locale,
+	});
+});

--- a/src/app/[locale]/dashboard/(user)/user/settings/_components/user-info.form.tsx
+++ b/src/app/[locale]/dashboard/(user)/user/settings/_components/user-info.form.tsx
@@ -1,13 +1,14 @@
 "use client";
 import type { User } from "@generated/client";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Loader, Phone, Shield, User as UserIcon } from "lucide-react";
+import { Loader, Phone, Shield, Trash2, User as UserIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import type { z } from "zod";
 import {
+	deleteAccount,
 	getUserHeaderImageUploadUrl,
 	getUserImageUploadUrl,
 	saveUserInformation,
@@ -15,6 +16,18 @@ import {
 import { userInfoShema } from "@/app/[locale]/dashboard/(user)/user/settings/_components/user-info.schema";
 import { LoaderSubmitButton } from "@/components/loader-submit-button";
 import { SlugInput } from "@/components/slug/slug-input";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import type { FileUploadItem } from "@/components/ui/file-upload";
 import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
@@ -454,6 +467,47 @@ export function UserInfoForm(props: UserInfoFormProps) {
 					</LoaderSubmitButton>
 				</form>
 			</Form>
+
+			<div className="mt-8 pt-8 border-t">
+				<div>
+					<h3 className="text-lg font-semibold flex items-center gap-2 text-destructive">
+						<Trash2 className="h-5 w-5" />
+						{t("dashboard.user.settings.deleteAccount.title")}
+					</h3>
+					<p className="text-sm text-muted-foreground mt-2 mb-4">
+						{t("dashboard.user.settings.deleteAccount.description")}
+					</p>
+					<AlertDialog>
+						<AlertDialogTrigger asChild>
+							<Button variant="destructive">{t("dashboard.user.settings.deleteAccount.button")}</Button>
+						</AlertDialogTrigger>
+						<AlertDialogContent>
+							<AlertDialogHeader>
+								<AlertDialogTitle>
+									{t("dashboard.user.settings.deleteAccount.confirmTitle")}
+								</AlertDialogTitle>
+								<AlertDialogDescription>
+									{t("dashboard.user.settings.deleteAccount.confirmDescription")}
+								</AlertDialogDescription>
+							</AlertDialogHeader>
+							<AlertDialogFooter>
+								<AlertDialogCancel>{t("common.actions.cancel")}</AlertDialogCancel>
+								<AlertDialogAction
+									onClick={async () => {
+										const result = await deleteAccount();
+										if (result?.serverError) {
+											toast.error(result.serverError);
+										}
+									}}
+									className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+								>
+									{t("dashboard.user.settings.deleteAccount.confirmButton")}
+								</AlertDialogAction>
+							</AlertDialogFooter>
+						</AlertDialogContent>
+					</AlertDialog>
+				</div>
+			</div>
 
 			<ImageCropDialog file={cropFile} onClose={handleCloseCrop} onCrop={handleCrop} />
 		</>

--- a/src/components/deleted-page.tsx
+++ b/src/components/deleted-page.tsx
@@ -1,0 +1,35 @@
+import Error404 from "@public/errors/404.webp";
+import type { Metadata } from "next";
+import Image from "next/image";
+import { getTranslations } from "next-intl/server";
+import { Button } from "@/components/ui/button";
+import { Link } from "@/i18n/navigation";
+
+export async function generateDeletedMetadata(): Promise<Metadata> {
+	const t = await getTranslations();
+
+	return {
+		title: t("public.deleted.title"),
+		description: t("public.deleted.metadata.description"),
+	};
+}
+
+export default async function DeletedPage() {
+	const t = await getTranslations();
+
+	return (
+		<main className="flex h-dvh w-full fade-in-up flex-col items-center justify-center p-8">
+			<Image src={Error404} alt="Deleted" draggable={false} className="w-full max-w-[400px] dark:invert" />
+			<h1 className="text-4xl font-bold mb-4 text-center">{t("public.deleted.title")}</h1>
+			<p className="text-lg mb-8 text-center">{t("public.deleted.message")}</p>
+			<Button asChild={true}>
+				<Link
+					href="/"
+					className="text-lg text-center hover:bg-accent transition-all bg-background px-4 py-2 rounded-md border"
+				>
+					{t("public.deleted.backHome")}
+				</Link>
+			</Button>
+		</main>
+	);
+}


### PR DESCRIPTION
Summary:
- Backend: add EntityType enum and DeletedEntity model; deletions record to DeletedEntity before removal (CLUB/EVENT/MEMBER, admin club remove, and new user deleteAccount flow with S3 cleanup and orphan club handling); minor revalidation tweaks.
- Frontend: render DeletedPage for removed clubs/events/users; New components/deleted-page.tsx with generateDeletedMetadata; Public pages now load DeletedPage when deletedEntity exists.
- User settings: add Delete Account UI with confirmation dialog wired to deleteAccount action; server action cleans S3 assets, unclaims orphan clubs, and redirects home.
- i18n: add public.deleted copy and delete-account strings (EN/BS).
- Misc: robots beta-mode behavior remains in place; sitemap omitted when NEXT_PUBLIC_BETA is true.
