### PR TITLE
fix: add top padding to club overview page

### DIFF
--- a/apps/web/src/app/[locale]/(public)/clubs/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(public)/clubs/[id]/page.tsx
@@ -207,7 +207,7 @@ export default async function Page(props: PageProps<"/[locale]/clubs/[id]">) {
 	}
 
 	return (
-		<div className="flex flex-col size-full gap-8 max-w-[1200px] pb-8 px-4">
+		<div className="flex flex-col size-full gap-8 max-w-[1200px] py-8 px-4">
 			<JsonLdScript data={sportsOrganizationSchema} />
 			<JsonLdScript data={breadcrumbSchema} />
 			{faqSchema && <JsonLdScript data={faqSchema} />}


### PR DESCRIPTION
Club overview public page used pb-8 (bottom only) while user and event pages use py-8 (top and bottom). This caused club banners to touch the navigation header.

Fixes #127 