### PR TITLE
feat: expose list_countries as an MCP tool

### DIFF
--- a/apps/backend/src/routes/clubs/core.ts
+++ b/apps/backend/src/routes/clubs/core.ts
@@ -25,7 +25,7 @@ const publicClubSchema = baseClubSchema.omit({
 
 const createClubBodySchema = z.object({
 	name: z.string().min(1).max(50),
-	countryId: z.number(),
+	countryId: z.number().describe("Country ID. Use the list_countries tool to find the correct ID."),
 	location: z.string().min(1).max(50),
 	latitude: z.number().optional(),
 	longitude: z.number().optional(),
@@ -45,7 +45,7 @@ const createClubBodySchema = z.object({
 
 const updateClubBodySchema = z.object({
 	name: z.string().min(1).max(50).optional(),
-	countryId: z.number().optional(),
+	countryId: z.number().optional().describe("Country ID. Use the list_countries tool to find the correct ID."),
 	location: z.string().min(1).max(50).optional(),
 	latitude: z.number().optional(),
 	longitude: z.number().optional(),

--- a/apps/backend/src/routes/countries.ts
+++ b/apps/backend/src/routes/countries.ts
@@ -117,10 +117,12 @@ countriesRouter.get(
 		schema: {
 			tags: ["Countries"],
 			summary: "Get all enabled countries",
-			description: "Returns a list of all enabled countries with their translations",
+			description:
+				"Returns a list of all enabled countries with their translations. Use this to look up a country's ID before passing it as countryId to other tools (e.g. creating or updating a club).",
 			response: {
 				200: z.array(countrySchema),
 			},
+			mcpTool: true,
 		},
 	},
 );


### PR DESCRIPTION
## Summary
- Expose `GET /countries` as an MCP tool (`list_countries`) so MCP clients can look up valid country IDs.
- Add a description to the `countryId` field on `create_club`/`update_club` pointing clients at `list_countries`.

Closes #136.

Generated with [Claude Code](https://claude.ai/code)