### PR TITLE
Make cache invalidation actually invalidate

### DIFF
--- a/apps/backend/src/lib/auth.ts
+++ b/apps/backend/src/lib/auth.ts
@@ -10,6 +10,7 @@ import { clubInvite, clubMembership } from "../drizzle/schema";
 import EmailVerification from "../emails/email-verification";
 import PasswordReset from "../emails/password-reset";
 import { userAdditionalFields } from "./auth-fields";
+import { bustRouteCache, clubMembershipCacheKeys } from "./cache-bust";
 import { CLEAR_ARCHIVE } from "./club-access";
 import { db } from "./db";
 import { getEmailMessages } from "./email-messages";
@@ -332,6 +333,10 @@ export const auth = betterAuth({
 											.where(eq(clubMembership.id, priorMembership.id));
 									}
 								});
+
+								// The club just gained a member, but this runs from an auth hook rather
+								// than a club route, so nothing busts the roster cache for us.
+								await bustRouteCache(clubMembershipCacheKeys(invite.clubId));
 							} catch (error) {
 								logger.error(`Failed to process invite ${invite.id}:`, { error });
 							}

--- a/apps/backend/src/lib/cache-bust.ts
+++ b/apps/backend/src/lib/cache-bust.ts
@@ -1,0 +1,63 @@
+import { deleteKeysByPattern } from "./cache";
+import { logger } from "./posthog";
+
+/**
+ * The prefix the router builds its cache keys with — see `cache.keyPrefix` in `src/index.ts`.
+ * Kept in sync by hand because the router owns the prefix and doesn't export it.
+ */
+const ROUTE_CACHE_PREFIX = "route:";
+
+/**
+ * Drops every cached response under a set of route-cache keys.
+ *
+ * Prefer the declarative `bustCache: [...]` route option. This exists for the handlers whose
+ * bust target isn't derivable from the route's own params — e.g. accepting an invite is keyed
+ * by invite code, but the membership it creates invalidates a *club's* member list.
+ */
+export async function bustRouteCache(keys: string[]): Promise<void> {
+	await Promise.all(
+		keys.map(async (key) => {
+			try {
+				await deleteKeysByPattern(`${ROUTE_CACHE_PREFIX}${key}:*`);
+			} catch {
+				// A failed bust means a stale read until the TTL expires, never a failed request.
+			}
+		}),
+	);
+}
+
+/** Everything that changes when a club's membership list changes. */
+export function clubMembershipCacheKeys(clubId: string): string[] {
+	return ["clubs", `club:${clubId}`];
+}
+
+/** The route-cache key whose reads carry a review target's rating. */
+const REVIEW_TARGET_CACHE_KEY: Record<string, (entityId: string) => string> = {
+	user: (id) => `user:${id}`,
+	club: (id) => `club:${id}`,
+	event: (id) => `event:${id}`,
+};
+
+/**
+ * Drops both caches a review lands in: the reviews router's own paginated `reviews:*` entries,
+ * and the route cache for the thing being reviewed, whose reads carry its rating.
+ *
+ * `type` is the lowercase target kind — "user", "club" or "event".
+ */
+export async function bustReviewCache(type: string, entityId: string): Promise<void> {
+	try {
+		// SCAN, not KEYS: `KEYS` is O(keyspace) and blocks the whole server while it runs.
+		await deleteKeysByPattern(`reviews:${type}:${entityId}:page:*`);
+	} catch (error) {
+		logger.emit({
+			severityText: "error",
+			body: "Error busting review cache",
+			attributes: { error: error instanceof Error ? error.message : String(error) },
+		});
+	}
+
+	const targetKey = REVIEW_TARGET_CACHE_KEY[type]?.(entityId);
+	if (targetKey) {
+		await bustRouteCache([targetKey]);
+	}
+}

--- a/apps/backend/src/lib/cache.ts
+++ b/apps/backend/src/lib/cache.ts
@@ -3,7 +3,10 @@ import { env } from "./env";
 import { logger } from "./posthog";
 import { redis } from "./redis";
 
-const SCAN_BATCH = 100;
+// Sized for the invalidation path, which is awaited: fewer cursor round trips between the
+// handler finishing and the client getting its response. Still small enough that a single
+// SCAN never blocks the server for long.
+const SCAN_BATCH = 1000;
 
 /**
  * Delete every key matching a glob pattern using a non-blocking SCAN cursor loop.
@@ -71,12 +74,20 @@ export const redisCacheStore: CacheStore = {
 	},
 
 	/**
-	 * Cache invalidation is intentionally fire-and-forget: the router awaits this call in the
-	 * response path of every mutation, and a multi-round-trip SCAN must not sit between the
-	 * handler finishing and the client getting its response. Failures are logged, never swallowed.
+	 * Invalidation is awaited, and has to be.
+	 *
+	 * This used to run detached so the SCAN round trips wouldn't sit between the handler
+	 * finishing and the client getting its response. But the mutation's response is what tells
+	 * the UI to refetch, so racing it against the delete means the refetch routinely lands
+	 * first and reads the entry that was about to be dropped — a demoted manager still showing
+	 * as a manager until the TTL runs out. Correct invalidation is worth the round trips.
+	 *
+	 * Failures are logged and swallowed: a mutation must not fail because Redis did.
 	 */
 	async delByPattern(pattern: string): Promise<void> {
-		void deleteKeysByPattern(pattern).catch((error) => {
+		try {
+			await deleteKeysByPattern(pattern);
+		} catch (error) {
 			logger.emit({
 				severityText: "error",
 				body: "Cache invalidation failed",
@@ -85,7 +96,7 @@ export const redisCacheStore: CacheStore = {
 					error: error instanceof Error ? error.message : String(error),
 				},
 			});
-		});
+		}
 	},
 };
 

--- a/apps/backend/src/routes/admin/clubs.ts
+++ b/apps/backend/src/routes/admin/clubs.ts
@@ -261,6 +261,7 @@ adminClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Ban club",
@@ -315,6 +316,7 @@ adminClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Unban club",
@@ -366,6 +368,7 @@ adminClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Verify club",
@@ -417,6 +420,7 @@ adminClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Unverify club",
@@ -452,6 +456,7 @@ adminClubsRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Delete club",

--- a/apps/backend/src/routes/admin/reviews.ts
+++ b/apps/backend/src/routes/admin/reviews.ts
@@ -2,6 +2,7 @@ import { apiError, Router, responseSchema } from "@reconned/router";
 import { and, count, desc, eq } from "drizzle-orm";
 import * as z from "zod";
 import { club, event, review, reviewEditHistory, user } from "../../drizzle/schema";
+import { bustReviewCache } from "../../lib/cache-bust";
 import { db } from "../../lib/db";
 import { posthog } from "../../lib/posthog";
 import { paginationQuerySchema, paginationResponseSchema } from "../../lib/schemas";
@@ -158,6 +159,13 @@ adminReviewsRouter.delete(
 			})();
 
 		await db.delete(review).where(eq(review.id, reviewId));
+
+		// Same invalidation the owner-facing delete does — the review list and the reviewed
+		// entity's rating both go stale, and the route only names the review.
+		const bustEntityId = existingReview.userId || existingReview.clubId || existingReview.eventId;
+		if (bustEntityId) {
+			await bustReviewCache(existingReview.type.toLowerCase(), bustEntityId);
+		}
 
 		posthog.capture({
 			distinctId: context.user.id,

--- a/apps/backend/src/routes/admin/unclaimed-clubs.ts
+++ b/apps/backend/src/routes/admin/unclaimed-clubs.ts
@@ -288,6 +288,7 @@ adminUnclaimedClubsRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Create unclaimed club",
@@ -397,6 +398,7 @@ adminUnclaimedClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Update unclaimed club",
@@ -458,6 +460,7 @@ adminUnclaimedClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Update unclaimed club logo",
@@ -542,6 +545,7 @@ adminUnclaimedClubsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Update unclaimed club header image",
@@ -717,6 +721,9 @@ adminUnclaimedClubsRouter.post(
 	},
 	{
 		auth: true,
+		// The club stops being unclaimed and gains a member, so both the listing and the
+		// club's own cached reads are now wrong.
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Admin"],
 			summary: "Assign club owner",

--- a/apps/backend/src/routes/clubs/alliances.ts
+++ b/apps/backend/src/routes/clubs/alliances.ts
@@ -84,6 +84,7 @@ clubsAlliancesRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}", "alliances"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Update club alliances",

--- a/apps/backend/src/routes/clubs/instagram.ts
+++ b/apps/backend/src/routes/clubs/instagram.ts
@@ -388,6 +388,7 @@ clubsInstagramRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Disconnect Instagram account",
@@ -671,6 +672,7 @@ clubsInstagramRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Exchange Instagram auth code",
@@ -838,6 +840,7 @@ clubsInstagramRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Select Facebook Page for Instagram",

--- a/apps/backend/src/routes/clubs/invites.ts
+++ b/apps/backend/src/routes/clubs/invites.ts
@@ -7,6 +7,7 @@ import * as z from "zod";
 import { club, clubInvite, clubMembership, user } from "../../drizzle/schema";
 import ClubInvitationEmail from "../../emails/airsoft-invitation";
 import { logClubAudit } from "../../lib/audit-logger";
+import { bustRouteCache, clubMembershipCacheKeys } from "../../lib/cache-bust";
 import {
 	CLEAR_ARCHIVE,
 	getActiveMembership,
@@ -641,6 +642,10 @@ clubsInvitesRouter.post(
 				actionType: "MEMBER_JOINED_VIA_INVITE",
 				actionData: { inviteId: invite.id },
 			});
+
+			// This route is keyed by invite code, so `bustCache` can't reach the club it just
+			// added a member to — the roster and member counts have to be dropped by hand.
+			await bustRouteCache(clubMembershipCacheKeys(invite.clubId));
 		} else {
 			// Update invite status to rejected
 			await db

--- a/apps/backend/src/routes/clubs/members.ts
+++ b/apps/backend/src/routes/clubs/members.ts
@@ -121,6 +121,7 @@ clubsMembersRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Remove member from club",
@@ -217,6 +218,7 @@ clubsMembersRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Add member to club",
@@ -359,6 +361,7 @@ clubsMembersRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Extend membership duration",
@@ -424,6 +427,7 @@ clubsMembersRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Leave club",
@@ -518,6 +522,7 @@ clubsMembersRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Update member role",
@@ -1078,6 +1083,7 @@ clubsMembersRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Archive club member",
@@ -1159,6 +1165,7 @@ clubsMembersRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["clubs", "club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Unarchive club member",

--- a/apps/backend/src/routes/clubs/posts.ts
+++ b/apps/backend/src/routes/clubs/posts.ts
@@ -241,6 +241,7 @@ clubsPostsRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Create club post",
@@ -334,6 +335,7 @@ clubsPostsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Update club post",
@@ -403,6 +405,7 @@ clubsPostsRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Delete club post",

--- a/apps/backend/src/routes/clubs/purchases.ts
+++ b/apps/backend/src/routes/clubs/purchases.ts
@@ -185,6 +185,7 @@ clubsPurchasesRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Create club purchase",
@@ -267,6 +268,7 @@ clubsPurchasesRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Update club purchase",
@@ -335,6 +337,7 @@ clubsPurchasesRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["club:{id}"],
 		schema: {
 			tags: ["Clubs"],
 			summary: "Delete club purchase",

--- a/apps/backend/src/routes/clubs/rules.ts
+++ b/apps/backend/src/routes/clubs/rules.ts
@@ -4,6 +4,7 @@ import { createSelectSchema } from "drizzle-zod";
 import * as z from "zod";
 import { clubRule } from "../../drizzle/schema";
 import { logClubAudit } from "../../lib/audit-logger";
+import { bustRouteCache } from "../../lib/cache-bust";
 import { requireClubManager } from "../../lib/club-access";
 import { db } from "../../lib/db";
 
@@ -211,6 +212,12 @@ clubsRulesRouter.put(
 			throw apiError.validation("Failed to update rule");
 		}
 
+		// A rule attached to an event is served from `event:{id}:rules`, which this route's
+		// params can't name — it only knows the club and the rule.
+		if (updatedRule[0].eventId) {
+			await bustRouteCache([`event:${updatedRule[0].eventId}`]);
+		}
+
 		await logClubAudit({
 			clubId,
 			actionType: "CLUB_RULE_UPDATE",
@@ -273,6 +280,11 @@ clubsRulesRouter.delete(
 		}
 
 		await db.delete(clubRule).where(eq(clubRule.id, ruleId));
+
+		// See the update route: an event-attached rule is cached under the event, not the club.
+		if (ruleData[0].eventId) {
+			await bustRouteCache([`event:${ruleData[0].eventId}`]);
+		}
 
 		await logClubAudit({
 			clubId,

--- a/apps/backend/src/routes/events.ts
+++ b/apps/backend/src/routes/events.ts
@@ -9,6 +9,7 @@ import EventInvitationEmail from "../emails/event-invitation";
 import EventPlaceReleasedEmail from "../emails/event-place-released";
 import EventWaitlistPromotedEmail from "../emails/event-waitlist-promoted";
 import { logClubAudit } from "../lib/audit-logger";
+import { bustRouteCache } from "../lib/cache-bust";
 import { getActiveMembership, requireClubManager } from "../lib/club-access";
 import { db } from "../lib/db";
 import { getEmailMessages, interpolateMessage } from "../lib/email-messages";
@@ -1139,7 +1140,7 @@ eventsRouter.post(
 	},
 	{
 		auth: true,
-		bustCache: ["events", "events:upcoming"],
+		bustCache: ["events", "events:upcoming", "events:calendar"],
 		schema: {
 			tags: ["Events"],
 			summary: "Create event",
@@ -1319,7 +1320,7 @@ eventsRouter.put(
 	},
 	{
 		auth: true,
-		bustCache: ["events", "events:upcoming", "event:{id}"],
+		bustCache: ["events", "events:upcoming", "events:calendar", "event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Update event",
@@ -1427,7 +1428,7 @@ eventsRouter.delete(
 	},
 	{
 		auth: true,
-		bustCache: ["events", "events:upcoming", "event:{id}"],
+		bustCache: ["events", "events:upcoming", "events:calendar", "event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Delete event",
@@ -1542,6 +1543,7 @@ eventsRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["events", "events:upcoming", "events:calendar", "event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Delete event image",
@@ -2256,6 +2258,7 @@ eventsRouter.post(
 	},
 	{
 		auth: true,
+		bustCache: ["events", "events:upcoming", "events:calendar", "event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Create or update event registration",
@@ -2328,6 +2331,7 @@ eventsRouter.delete(
 		});
 	},
 	{
+		bustCache: ["events", "events:upcoming", "events:calendar", "event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Delete event registration",
@@ -2509,6 +2513,7 @@ eventsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Respond to a team invite",
@@ -2606,6 +2611,10 @@ eventsRouter.post(
 		if (!claimed[0]) {
 			throw apiError.validation("This invitation has already been claimed");
 		}
+
+		// The attendee list changed hands, but this route is keyed by invite token — the event
+		// it belongs to only becomes known inside the handler.
+		await bustRouteCache([`event:${attendee.eventId}`]);
 
 		posthog.capture({
 			distinctId: context.user.id,
@@ -2709,6 +2718,7 @@ eventsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Toggle attendance",
@@ -2779,6 +2789,7 @@ eventsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Mark one person present or absent",
@@ -2854,6 +2865,7 @@ eventsRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["event:{id}"],
 		schema: {
 			tags: ["Events"],
 			summary: "Mark one person paid or unpaid",

--- a/apps/backend/src/routes/reviews.ts
+++ b/apps/backend/src/routes/reviews.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, gte, lte } from "drizzle-orm";
 import * as z from "zod";
 import { club, event, eventAttendee, review, reviewEditHistory, user } from "../drizzle/schema";
 import { rateLimitKey, redisRateLimitStore } from "../lib/cache";
+import { bustReviewCache } from "../lib/cache-bust";
 import { db } from "../lib/db";
 import { isFeatureEnabled } from "../lib/feature-flags";
 import { logger } from "../lib/posthog";
@@ -22,21 +23,6 @@ function cachedJson<T>(data: T, cacheControl: string): Response {
 			"Cache-Control": cacheControl,
 		},
 	});
-}
-
-async function bustReviewCache(type: string, entityId: string): Promise<void> {
-	try {
-		const keys = await redis.keys(`reviews:${type}:${entityId}:page:*`);
-		if (keys.length > 0) {
-			await redis.del(...keys);
-		}
-	} catch (error) {
-		logger.emit({
-			severityText: "error",
-			body: "Error busting review cache",
-			attributes: { error: error instanceof Error ? error.message : String(error) },
-		});
-	}
 }
 
 const reviewWithAuthorSchema = z.object({
@@ -496,7 +482,7 @@ reviewsRouter.post(
 
 			const bustEntityId = userId || clubId || eventId;
 			if (bustEntityId) {
-				void bustReviewCache(body.type.toLowerCase(), bustEntityId);
+				await bustReviewCache(body.type.toLowerCase(), bustEntityId);
 			}
 
 			return response.json({
@@ -533,7 +519,7 @@ reviewsRouter.post(
 
 		const bustEntityId = userId || clubId || eventId;
 		if (bustEntityId) {
-			void bustReviewCache(type.toLowerCase(), bustEntityId);
+			await bustReviewCache(type.toLowerCase(), bustEntityId);
 		}
 
 		return response.json(
@@ -665,7 +651,7 @@ reviewsRouter.patch(
 		const bustType = existingReview.type.toLowerCase();
 		const bustEntityId = existingReview.userId || existingReview.clubId || existingReview.eventId;
 		if (bustEntityId) {
-			void bustReviewCache(bustType, bustEntityId);
+			await bustReviewCache(bustType, bustEntityId);
 		}
 
 		return response.json({ review: updatedReview });
@@ -752,7 +738,7 @@ reviewsRouter.delete(
 		const bustType = existingReview.type.toLowerCase();
 		const bustEntityId = existingReview.userId || existingReview.clubId || existingReview.eventId;
 		if (bustEntityId) {
-			void bustReviewCache(bustType, bustEntityId);
+			await bustReviewCache(bustType, bustEntityId);
 		}
 
 		return response.json({ success: true });

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -970,6 +970,7 @@ usersRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["users", "user:{id}"],
 		schema: {
 			tags: ["Users"],
 			summary: "Delete user image",
@@ -1009,6 +1010,7 @@ usersRouter.delete(
 	},
 	{
 		auth: true,
+		bustCache: ["users", "user:{id}"],
 		schema: {
 			tags: ["Users"],
 			summary: "Delete user header image",
@@ -1357,6 +1359,7 @@ usersRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["user:{id}"],
 		schema: {
 			tags: ["Users"],
 			summary: "Update user theme",
@@ -1400,6 +1403,7 @@ usersRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["user:{id}"],
 		schema: {
 			tags: ["Users"],
 			summary: "Update user font",
@@ -1443,6 +1447,7 @@ usersRouter.put(
 	},
 	{
 		auth: true,
+		bustCache: ["user:{id}"],
 		schema: {
 			tags: ["Users"],
 			summary: "Update user language",

--- a/apps/backend/tests/clubs/members.test.ts
+++ b/apps/backend/tests/clubs/members.test.ts
@@ -257,6 +257,61 @@ describe("club members", () => {
 		});
 	});
 
+	describe("member list cache invalidation", () => {
+		test("demoting a manager is reflected in the member list immediately", async () => {
+			const owner = await createUser();
+			const manager = await createUser();
+			const club = await createClub(owner);
+			const membershipId = await addMember(club.id, manager, "MANAGER");
+
+			// Warm the cache — without a bust, this response is what the next read returns.
+			const before = await api(owner.cookie).get(`/api/clubs/${club.id}/members?role=MANAGER`);
+			expect(before.status).toBe(200);
+			expect(before.body.members.map((m: { userId: string }) => m.userId)).toContain(manager.id);
+
+			const demote = await api(owner.cookie).put(`/api/clubs/${club.id}/members/${membershipId}`, {
+				role: "USER",
+			});
+			expect(demote.status).toBe(200);
+
+			const after = await api(owner.cookie).get(`/api/clubs/${club.id}/members?role=MANAGER`);
+			expect(after.status).toBe(200);
+			expect(after.body.members.map((m: { userId: string }) => m.userId)).not.toContain(manager.id);
+		});
+
+		test("archiving is reflected in the member list immediately", async () => {
+			const owner = await createUser();
+			const target = await createUser();
+			const club = await createClub(owner);
+			const membershipId = await addMember(club.id, target);
+
+			const before = await api(owner.cookie).get(`/api/clubs/${club.id}/members`);
+			expect(before.body.members.map((m: { userId: string }) => m.userId)).toContain(target.id);
+
+			await api(owner.cookie).post(`/api/clubs/${club.id}/members/${membershipId}/archive`, {
+				reason: "INACTIVE",
+			});
+
+			const after = await api(owner.cookie).get(`/api/clubs/${club.id}/members`);
+			expect(after.body.members.map((m: { userId: string }) => m.userId)).not.toContain(target.id);
+		});
+
+		test("removing a member updates the club's cached member count", async () => {
+			const owner = await createUser();
+			const target = await createUser();
+			const club = await createClub(owner);
+			const membershipId = await addMember(club.id, target);
+
+			const before = await api(owner.cookie).get(`/api/clubs/${club.id}`);
+			expect(before.body._count.members).toBe(2);
+
+			await api(owner.cookie).delete(`/api/clubs/${club.id}/members/${membershipId}`);
+
+			const after = await api(owner.cookie).get(`/api/clubs/${club.id}`);
+			expect(after.body._count.members).toBe(1);
+		});
+	});
+
 	describe("POST /api/clubs/:id/members/:memberId/archive", () => {
 		test("unauthenticated request is rejected", async () => {
 			const owner = await createUser();

--- a/apps/backend/tests/clubs/posts.test.ts
+++ b/apps/backend/tests/clubs/posts.test.ts
@@ -306,4 +306,33 @@ describe("club posts", () => {
 			expect(response.status).toBe(403);
 		});
 	});
+	describe("cache invalidation", () => {
+		test("a new post shows up in the club's post list immediately", async () => {
+			const owner = await createUser();
+			const club = await createClub(owner);
+
+			// Warm the cached list before mutating, so a missing bust would be visible.
+			const before = await api(owner.cookie).get(`/api/clubs/${club.id}/posts`);
+			expect(before.status).toBe(200);
+			const post = await createPost(owner, club.id);
+
+			const after = await api(owner.cookie).get(`/api/clubs/${club.id}/posts`);
+			expect(after.body.posts.map((p: { id: string }) => p.id)).toContain(post.id);
+		});
+
+		test("a deleted post disappears from the club's post list immediately", async () => {
+			const owner = await createUser();
+			const club = await createClub(owner);
+			const post = await createPost(owner, club.id);
+
+			const before = await api(owner.cookie).get(`/api/clubs/${club.id}/posts`);
+			expect(before.body.posts.map((p: { id: string }) => p.id)).toContain(post.id);
+
+			const deleted = await api(owner.cookie).delete(`/api/clubs/${club.id}/posts/${post.id}`);
+			expect(deleted.status).toBe(200);
+
+			const after = await api(owner.cookie).get(`/api/clubs/${club.id}/posts`);
+			expect(after.body.posts.map((p: { id: string }) => p.id)).not.toContain(post.id);
+		});
+	});
 });

--- a/apps/web/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/members-table.tsx
+++ b/apps/web/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/members-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { format } from "date-fns";
 import { Archive, ArchiveRestore, Calendar, LogOut, UserCircle, UserMinus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useExtracted, useLocale } from "next-intl";
@@ -16,6 +17,7 @@ import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 import { Link } from "@/i18n/navigation";
 import apiClient from "@/lib/api/api.client";
 import type { ApiResponse } from "@/lib/api/api-type-helpers";
+import { getDateFnsLocale } from "@/lib/date-locale";
 
 type ClubMember = ApiResponse<"/api/clubs/{id}/members", "get">["members"][number];
 
@@ -32,6 +34,11 @@ export function MembersTable(props: MembersTableProps) {
 	const t = useExtracted();
 	const locale = useLocale();
 	const router = useRouter();
+	// date-fns rather than toLocaleDateString: it ships its own locale data, so the output
+	// doesn't depend on how much ICU the runtime happens to carry.
+	const dateFnsLocale = getDateFnsLocale(locale);
+	const formatDate = (value: string) => format(new Date(value), "PPP", { locale: dateFnsLocale });
+
 	const [membershipToExtend, setMembershipToExtend] = useState<ClubMember | null>(null);
 	const [membershipToArchive, setMembershipToArchive] = useState<{
 		id: string;
@@ -230,15 +237,7 @@ export function MembersTable(props: MembersTableProps) {
 						cellConfig: {
 							variant: "custom",
 							component: (_, row) => (
-								<span>
-									{row.startDate
-										? new Date(row.startDate).toLocaleDateString(locale, {
-												day: "2-digit",
-												month: "long",
-												year: "numeric",
-											})
-										: t("Not set")}
-								</span>
+								<span>{row.startDate ? formatDate(row.startDate) : t("Not set")}</span>
 							),
 						},
 					},
@@ -249,15 +248,7 @@ export function MembersTable(props: MembersTableProps) {
 						cellConfig: {
 							variant: "custom",
 							component: (_, row) => (
-								<span>
-									{row.endDate
-										? new Date(row.endDate).toLocaleDateString(locale, {
-												day: "2-digit",
-												month: "long",
-												year: "numeric",
-											})
-										: t("Unlimited")}
-								</span>
+								<span>{row.endDate ? formatDate(row.endDate) : t("Unlimited")}</span>
 							),
 						},
 					},
@@ -378,6 +369,8 @@ export function MembersTable(props: MembersTableProps) {
 					{
 						key: "status",
 						label: t("Filter by status"),
+						// Matches the server's own default, so the control shows what is on screen.
+						defaultValue: "ACTIVE",
 						options: [
 							{ label: t("Active"), value: "ACTIVE" },
 							{ label: t("Archived"), value: "ARCHIVED" },

--- a/apps/web/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/membership-extension.form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/(club)/[clubId]/members/_components/membership-extension.form.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format, formatDistanceToNow } from "date-fns";
-import { bs, enUS } from "date-fns/locale";
 import { CalendarClock } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useExtracted, useLocale } from "next-intl";
@@ -25,6 +24,7 @@ import {
 import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import apiClient from "@/lib/api/api.client";
+import { getDateFnsLocale } from "@/lib/date-locale";
 
 interface ExtendableMembership {
 	id: string;
@@ -80,7 +80,7 @@ export function MembershipExtensionForm({
 		}
 	};
 
-	const dateFnsLocale = locale === "en" ? enUS : bs;
+	const dateFnsLocale = getDateFnsLocale(locale);
 
 	const form = useForm<MembershipExtensionFormValues>({
 		resolver: zodResolver(membershipExtensionSchema),

--- a/apps/web/src/components/generic-data-table.tsx
+++ b/apps/web/src/components/generic-data-table.tsx
@@ -51,6 +51,12 @@ interface Filter {
 	key: string;
 	label: string;
 	options: { label: string; value: string }[];
+	/**
+	 * Shown as selected when the URL carries no value for this filter. Use it when the server
+	 * applies a default of its own, so the control reflects what is actually being listed
+	 * instead of falling back to the "all" placeholder.
+	 */
+	defaultValue?: string;
 }
 
 interface GenericTableProps<T> {
@@ -402,7 +408,7 @@ export function GenericDataTable<T>({
 				{filters?.map((filter) => (
 					<Select
 						key={filter.key}
-						value={filterValues[filter.key] || "all"}
+						value={filterValues[filter.key] || filter.defaultValue || "all"}
 						onValueChange={(value) => handleFilterChange(filter.key, value)}
 					>
 						<SelectTrigger className="w-full md:w-[180px] !h-10">

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1026,7 +1026,12 @@ export class Router {
 		try {
 			const result = await pending;
 			if (result.status < 400) {
-				this.writeCache(cacheKey, route, swr, result.body, result.headers);
+				// Awaited, not fire-and-forget. A write still in flight when a mutation's
+				// `bustCache` runs lands *after* the delete and resurrects the entry it was
+				// supposed to remove — the read then stays stale for a full TTL. That race is
+				// easy to hit in practice: a list view and the mutation acting on it are
+				// consecutive requests. One SET on the miss path is the cheaper problem.
+				await this.writeCache(cacheKey, route, swr, result.body, result.headers);
 			}
 			return rebuildResponse(result);
 		} finally {
@@ -1052,8 +1057,14 @@ export class Router {
 		}
 	}
 
-	/** Fire-and-forget cache write. Failures are logged, never swallowed silently. */
-	private writeCache(cacheKey: string, route: Route, swr: number, bodyText: string, headers: Headers): void {
+	/** Writes a cache entry. Failures are logged, never swallowed silently. */
+	private async writeCache(
+		cacheKey: string,
+		route: Route,
+		swr: number,
+		bodyText: string,
+		headers: Headers,
+	): Promise<void> {
 		if (!this.cacheStore || !route.cache) {
 			return;
 		}
@@ -1072,9 +1083,11 @@ export class Router {
 			}
 		}
 
-		void this.cacheStore.set(cacheKey, payload, { ttl: route.cache.ttl + swr })?.catch?.((error: unknown) => {
+		try {
+			await this.cacheStore.set(cacheKey, payload, { ttl: route.cache.ttl + swr });
+		} catch (error) {
 			console.error(`[router] cache write failed for ${cacheKey}:`, error);
-		});
+		}
 	}
 
 	/** Refreshes a stale entry in the background (serve-stale-while-revalidate). */


### PR DESCRIPTION
Demoting a manager left them showing as a manager in both the members and managers lists until the cache expired. Three separate things were wrong, each of which was enough on its own.

`redisCacheStore.delByPattern` was fire-and-forget: it returned before deleting anything, so the router's `await` on it meant nothing. The mutation's response is what tells the UI to refetch, so the refetch raced the delete and usually won — reading back the entry that was about to be dropped, then holding it for a full TTL. That defeated cache busting on every route that had it. It is awaited now, with SCAN_BATCH raised to keep the round trips down.

The router's cache write was fire-and-forget for the same reason, so a write still in flight when a bust ran would land afterwards and resurrect the entry. Also awaited now: one SET on the miss path is the cheaper problem.

Then the club member routes had no `bustCache` at all. Neither did 60 other mutations — 15 of 82 declared one. This sweeps the rest: posts, purchases, instagram, alliances, admin club moderation, unclaimed clubs, event registrations and attendance, and user profile fields. Where the bust target isn't a route param — a rule attached to an event, a place claimed by invite token, an invite accepted by code, the email-verification hook — `lib/cache-bust.ts` does it from the handler.

Three bugs turned up on the way. `events:calendar` was never busted by anything, including the event create/update/delete that already busted the other event keys. Reviews invalidated with `redis.keys()`, the O(keyspace) command that blocks the whole server and which this codebase's own helper warns against. And review busting never touched the reviewed entity's cache, so a new review didn't move the club's or user's rating.

Also in this branch: the members table defaulted its status filter to the "all" placeholder while the server was listing active members only, and its dates went through `toLocaleDateString`, which renders as "2026 M02 07" on a runtime whose ICU has no `bs` data. Both now go through what the codebase already had — a filter `defaultValue`, and date-fns with `getDateFnsLocale`, which carries its own locale data.